### PR TITLE
Programming Projects Page Update

### DIFF
--- a/css/body.css
+++ b/css/body.css
@@ -12,3 +12,22 @@
     margin-left:auto;
     margin-right:auto;
 }
+
+#projects-table {
+    table-layout:fixed;
+    border:1px solid #343231;
+    border-collapse: collapse;
+    width:100%;
+}
+
+#projects-table th {
+    border:1px solid #343231;
+    border-collapse:collapse;
+}
+
+#projects-table td {
+    width:50%;
+    border-left:1px solid #343231;
+    border-top:1px dashed #343231;
+    border-collapse:collapse;
+}

--- a/programming-projects/programming-projects.html
+++ b/programming-projects/programming-projects.html
@@ -131,11 +131,11 @@ async function addTableElement( repository ) {
 
     // create HTML for deployed homepage if it exists
     const website = gitrepo.info.data.homepage;
-    const websiteString = website == "" ? "" : "<p>Deployed Website: <a href=\">" + website + "\">" + website + "</a></p>"
+    const websiteString = website == "" ? "" : "<li>Deployed Website: <a href=\">" + website + "\">" + website + "</a></li>"
 
     // create HTML for public githup repository if it exists
     const githubLink = gitrepo.info.data.html_url;
-    const githubString = "<p>GitHub Link: <a href=\"" + githubLink + "\">" + githubLink + "</a></p>";
+    const githubString = "<li>GitHub Link: <a href=\"" + githubLink + "\">" + githubLink + "</a></li>";
 
     document.getElementById(repository).innerHTML = nameString
         + "<ul>"

--- a/programming-projects/programming-projects.html
+++ b/programming-projects/programming-projects.html
@@ -22,6 +22,110 @@
         </nav>
         <h1>Programming Projects</h1>
     </div>
-    <div id="body"></div>
+    <div id="body">
+        <ul id="projects-list"></ul>
+    </div>
 </body>
+
+<script type="module" type="text/javascript">
+// init octokit
+import { Octokit, App } from "https://esm.sh/octokit";
+const octokit = new Octokit({
+    auth: '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'  // THIS IS JUST A PUBLIC_REPO KEY!
+});
+
+// variables
+const username = "mwhicks-dev";
+const repositories = [ "registrar", "mwhicks-dev.github.io" ];
+
+// functions
+async function accessGitAPI( repository ) {
+    var info = await octokit.request("GET /repos/{owner}/{repo}",{
+        owner: username,
+        repo: repository
+    });
+    var merged_pulls = await octokit.request("GET /repos/{owner}/{repo}/pulls?state=closed",{
+        owner: username,
+        repo: repository
+    });
+    var languages = await octokit.request("GET /repos/{owner}/{repo}/languages",{
+        owner: username,
+        repo: repository
+    });
+
+    return {
+        info, merged_pulls, languages
+    };
+}
+
+async function makeLanguagesPercentage( languages ) {
+    const keys = Object.keys( languages );
+
+    var total = 0;
+    for ( i in keys ) {
+        const key = keys[ i ];
+        total += parseInt( languages[ key ] );
+    }
+    for ( i in keys ) {
+        const key = keys[ i ];
+        languages[ key ] = ( parseInt( 100 * parseInt( languages[ key ] ) / total ) ) + "%";
+    }
+}
+
+async function addListElement( repository ) {
+
+    // get repo using async API function
+    const gitrepo = await accessGitAPI( repository );
+
+    // create HTML for repository name
+    const name = gitrepo.info.data.name;
+    const nameString = "<p>Project Title: " + name + "</p>";
+
+    // create HTML for repository description if it exists
+    const desc = gitrepo.info.data.description;
+    const descString = desc == null ? "" : "<p>Project Description: " + desc + "</p>";
+
+    // create HTML for repository langauges
+    var languages = gitrepo.languages.data
+    await makeLanguagesPercentage( languages );
+    var languagesString = "<p>Languages:<ul>";
+
+    const languages_keys = Object.keys( languages );
+    for ( i in languages_keys ) {
+        const key = languages_keys[ i ];
+        const val = languages[ key ];
+        languagesString += "<li>" + key + ": " + ( val == "0%" ? "<1%" : val ) + "</li>";
+    }
+    languagesString += "</ul>";
+
+    // create HTML for deployed homepage if it exists
+    const website = gitrepo.info.data.homepage;
+    const websiteString = website == "" ? "" : "<p>Deployed Website: <a href=\">" + website + "\">" + website + "</a></p>"
+
+    // create HTML for public githup repository if it exists
+    const githubLink = gitrepo.info.data.html_url;
+    const githubString = "<p>GitHub Link: <a href=\"" + githubLink + "\">" + githubLink + "</a></p>";
+
+    document.getElementById("projects-list").insertAdjacentHTML( "beforeend",
+        "<li>"
+        + nameString
+        + descString
+        + languagesString
+        + websiteString
+        + githubString
+        + "</li>"
+    );
+}
+
+// run js
+var i;
+for ( i in repositories ) {
+    await addListElement( repositories[ i ] );
+}
+
+
+var repo = await accessGitAPI( repositories[ 0 ] );
+console.log(repo.languages.data)
+</script>
+
 </html>

--- a/programming-projects/programming-projects.html
+++ b/programming-projects/programming-projects.html
@@ -133,6 +133,14 @@ async function addTableElement( repository ) {
     const website = gitrepo.info.data.homepage;
     const websiteString = website == "" ? "" : "<li>Deployed Website: <a href=\">" + website + "\">" + website + "</a></li>"
 
+    // create HTML for latest pull
+    const merged_pulls = gitrepo.merged_pulls.data;
+    var pull_string = "";
+    if ( merged_pulls.length > 0 ) {
+        const latest_pull = merged_pulls[ 0 ];
+        pull_string += "<li><p>Latest Pull: " + latest_pull.title + "</p><p>" + latest_pull.body + "</p></li>";
+    }
+
     // create HTML for public githup repository if it exists
     const githubLink = gitrepo.info.data.html_url;
     const githubString = "<li>GitHub Link: <a href=\"" + githubLink + "\">" + githubLink + "</a></li>";
@@ -142,6 +150,7 @@ async function addTableElement( repository ) {
         + descString
         + languagesString
         + websiteString
+        + pull_string
         + githubString
         + "</ul>";
 }
@@ -155,6 +164,9 @@ for ( var i in active_repositories ) {
 for ( var i in complete_repositories ) {
     await addTableElement( complete_repositories[ i ] );
 }
+
+const repo = accessGitAPI( active_repositories[ 1 ] );
+console.log(repo)
 </script>
 
 </html>

--- a/programming-projects/programming-projects.html
+++ b/programming-projects/programming-projects.html
@@ -8,4 +8,20 @@
     <link rel="stylesheet" href="../css/body.css">
     <title>Mason's Portfolio Site | Nick</title>
 </head>
+<body>
+    <div id="header">
+        <nav>
+            <div id="nav-menu">
+                <ul>
+                    <li class="nav-link"><a href="../index.html">Home</a></li>
+                    <li class="nav-link"><a href="#">Programming Projects</a></li>
+                    <li class="nav-link"><a href="../nick/nick.html">Nick</a></li>
+                    <!-- <li class="nav"><a href=""></a></li> -->
+                </ul>
+            </div>
+        </nav>
+        <h1>Programming Projects</h1>
+    </div>
+    <div id="body"></div>
+</body>
 </html>

--- a/programming-projects/programming-projects.html
+++ b/programming-projects/programming-projects.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="../css/main.css">
     <link rel="stylesheet" href="../css/header.css">
     <link rel="stylesheet" href="../css/body.css">
-    <title>Mason's Portfolio Site | Nick</title>
+    <title>Mason's Portfolio Site | Programming Projects</title>
 </head>
 <body>
     <div id="header">

--- a/programming-projects/programming-projects.html
+++ b/programming-projects/programming-projects.html
@@ -23,7 +23,12 @@
         <h1>Programming Projects</h1>
     </div>
     <div id="body">
-        <ul id="projects-list"></ul>
+        <table id="projects-table">
+            <tr>
+                <th>Active</th>
+                <th>Complete</th>
+            </tr>
+        </table>
     </div>
 </body>
 
@@ -36,9 +41,35 @@ const octokit = new Octokit({
 
 // variables
 const username = "mwhicks-dev";
-const repositories = [ "registrar", "mwhicks-dev.github.io" ];
+const active_repositories = [ "registrar", "mwhicks-dev.github.io" ];
+const complete_repositories = [];
 
 // functions
+function createTable() {
+    var active_len = parseInt( active_repositories.length );
+    var complete_len = parseInt( complete_repositories.len );
+
+    if ( Number.isNaN( active_len ) )  active_len = 0;
+    if ( Number.isNaN( complete_len ) )  complete_len = 0;
+
+    const table_height = active_len > complete_len ? active_len : complete_len;
+
+    const table = document.getElementById("projects-table")
+    for ( var i = 0; i < table_height; i++ ) {
+        var row = document.createElement("tr");
+        var activeColumn = document.createElement("td");
+        var completeColumn = document.createElement("td");
+
+        if ( i < active_len ) { activeColumn.id = active_repositories[ i ]; }
+        if ( i < complete_len ) { activeColumn.id = complete_repositories[ i ]; }
+
+        row.appendChild( activeColumn );
+        row.appendChild( completeColumn );
+
+        table.appendChild( row );
+    }
+}
+
 async function accessGitAPI( repository ) {
     var info = await octokit.request("GET /repos/{owner}/{repo}",{
         owner: username,
@@ -72,7 +103,7 @@ async function makeLanguagesPercentage( languages ) {
     }
 }
 
-async function addListElement( repository ) {
+async function addTableElement( repository ) {
 
     // get repo using async API function
     const gitrepo = await accessGitAPI( repository );
@@ -83,12 +114,12 @@ async function addListElement( repository ) {
 
     // create HTML for repository description if it exists
     const desc = gitrepo.info.data.description;
-    const descString = desc == null ? "" : "<p>Project Description: " + desc + "</p>";
+    const descString = desc == null ? "" : "<li>Project Description: " + desc + "</li>";
 
     // create HTML for repository langauges
     var languages = gitrepo.languages.data
     await makeLanguagesPercentage( languages );
-    var languagesString = "<p>Languages:<ul>";
+    var languagesString = "<li>Languages:<ul>";
 
     const languages_keys = Object.keys( languages );
     for ( i in languages_keys ) {
@@ -96,7 +127,7 @@ async function addListElement( repository ) {
         const val = languages[ key ];
         languagesString += "<li>" + key + ": " + ( val == "0%" ? "<1%" : val ) + "</li>";
     }
-    languagesString += "</ul>";
+    languagesString += "</ul></li>";
 
     // create HTML for deployed homepage if it exists
     const website = gitrepo.info.data.homepage;
@@ -106,26 +137,24 @@ async function addListElement( repository ) {
     const githubLink = gitrepo.info.data.html_url;
     const githubString = "<p>GitHub Link: <a href=\"" + githubLink + "\">" + githubLink + "</a></p>";
 
-    document.getElementById("projects-list").insertAdjacentHTML( "beforeend",
-        "<li>"
-        + nameString
+    document.getElementById(repository).innerHTML = nameString
+        + "<ul>"
         + descString
         + languagesString
         + websiteString
         + githubString
-        + "</li>"
-    );
+        + "</ul>";
 }
 
 // run js
-var i;
-for ( i in repositories ) {
-    await addListElement( repositories[ i ] );
+createTable();
+
+for ( var i in active_repositories ) {
+    await addTableElement( active_repositories[ i ] );
 }
-
-
-var repo = await accessGitAPI( repositories[ 0 ] );
-console.log(repo.languages.data)
+for ( var i in complete_repositories ) {
+    await addTableElement( complete_repositories[ i ] );
+}
 </script>
 
 </html>


### PR DESCRIPTION
<!-- FOR HTML PURPOSES ON HICKSM.DEV --><p>Added scalable functionality to the Programming Projects page on my website.</p><p>Changelog:<ul>
<li>Created (and modified) table header code from index site to work for the projects site;</li>
<li>Changed programming projects page title error (was previously same as Nick page)</li>
<li>Created scalable JavaScript inline file that can access public repositories which I have listed in the script and initialize the website's table with them using the Octokit REST library for JavaScript</li>
<li>Made simple CSS for my table that I feel reflects the rest of my site</li>
</ul></p><p>Future Changes to Programming Projects:<ul>
<li>Change JS components to be fully automated; use GitHub project descriptions and stuff to generate flags that handle all of the user discretion (do I consider this repository? Is it complete or active?) based on that flag instead of me having to code it... this would make the project even more scalable. It does ring the question of how GitHub orders my public repositories... but I'll cross that bridge when I get to it.</li>
</ul></p>